### PR TITLE
ssd를 release 모드로  실행할 때, cout, cerr 등 화면에 출력하는것이 없도록 수정

### DIFF
--- a/TeamBest_SSD/TestCommandBuffer.cpp
+++ b/TeamBest_SSD/TestCommandBuffer.cpp
@@ -35,7 +35,9 @@ std::vector<std::string> GetFilesInDirectory(const std::string& directoryPath) {
 		}
 	}
 	catch (const fs::filesystem_error& e) {
+#ifdef _DEBUG
 		std::cerr << "파일 목록 검사 중 오류 발생: " << e.what() << '\n';
+#endif
 	}
 
 	return fileList;

--- a/TeamBest_SSD/command_buffer.cpp
+++ b/TeamBest_SSD/command_buffer.cpp
@@ -42,7 +42,9 @@ void CommandBuffer::MakeEmptyFiles() {
 		std::ofstream outFile(fileName);
 		if (outFile) outFile.close();
 		else {
+#ifdef _DEBUG
 			std::cerr << "파일을 생성하는 데 실패했습니다!" << fileName << '\n';
+#endif	
 		}
 	}
 }
@@ -99,7 +101,9 @@ std::string CommandBuffer::GetFirstEmptyBuffer() {
 		}		
 	}
 	catch (const fs::filesystem_error& e) {
+#ifdef _DEBUG
 		std::cerr << "파일 목록 검사 중 오류 발생: " << e.what() << '\n';
+#endif
 	}
 
 	return emptyBuffer;
@@ -118,6 +122,8 @@ void CommandBuffer::WriteCommandToBuffer(
 		fs::rename(oldBufferPath, newBufferPath);
 	}
 	catch (const fs::filesystem_error& e) {
+#ifdef _DEBUG
 		std::cerr << "Buffer 이름 변경 실패: " << e.what() << '\n';
+#endif
 	}
 }

--- a/TeamBest_SSD/main.cpp
+++ b/TeamBest_SSD/main.cpp
@@ -13,7 +13,7 @@ int main(int argc, char* argv[])
 {
 #ifdef _DEBUG
     ::testing::InitGoogleMock();
-    ::testing::GTEST_FLAG(filter) = "TestCommandBuffer.*";
+    //::testing::GTEST_FLAG(filter) = "TestCommandBuffer.*";
     return RUN_ALL_TESTS();
 #else
     std::string ssdFefaultType{ "SSD" };
@@ -26,9 +26,7 @@ int main(int argc, char* argv[])
     for (int i = 1; i < argc; ++i)
         commandLine = commandLine + " " + std::string{ argv[i] };
 
-    std::cout << "Input Command : " << commandLine << std::endl;
     ssdController.Run(commandLine);
-    std::cout << "Done\n";
 
     return 0;
 #endif

--- a/TeamBest_SSD/ssd.cpp
+++ b/TeamBest_SSD/ssd.cpp
@@ -82,7 +82,9 @@ std::pair<int, std::string> SSD::SplitLineToLbaAndValue(const std::string& line)
 void  SSD::ReadValueAtAddress(int lba) {
     std::ifstream file(NAND_FILE_PATH);
     if (!file.is_open()) {
+#ifdef _DEBUG
         std::cerr << "파일을 열 수 없습니다!" << NAND_FILE_PATH << '\n';
+#endif 
         return WriteValueToOutputFile(ERROR_MESSAGE);
     }
 
@@ -95,7 +97,9 @@ void  SSD::ReadValueAtAddress(int lba) {
             readLba = convertedLine.first;
             readValue = convertedLine.second;
             if (readLba != lba) {
+#ifdef _DEBUG
                 std::cout << "파일에 해당 주소가 없습니다.: " << lba << "\n";
+#endif
                 return WriteValueToOutputFile(ERROR_MESSAGE);
             }
             break;
@@ -110,7 +114,9 @@ void  SSD::ReadValueAtAddress(int lba) {
 void SSD::WriteValueToOutputFile(const std::string& value) {
     std::ofstream outFile(OUTPUT_FILE_PATH, std::ios::trunc);
     if (!outFile) {
+#ifdef _DEBUG
         std::cerr << "파일을 열 수 없습니다: " << OUTPUT_FILE_PATH << '\n';
+#endif
         return;
     }
 
@@ -121,7 +127,9 @@ void SSD::WriteValueToOutputFile(const std::string& value) {
 void SSD::UpdateValueAtAddress(int lba, const std::string& value) {
     std::vector<std::string> entireData = ReadDataForEntireAddress();
     if (entireData.size() != GetEntireAddressSize()) {
+#ifdef _DEBUG
         std::cerr << "메모리 크기와 읽은 데이터의 수가 다릅니다!\n";
+#endif
         return;
     }
 
@@ -136,7 +144,9 @@ std::vector<std::string> SSD::ReadDataForEntireAddress() {
 
     std::ifstream inFile(NAND_FILE_PATH);
     if (!inFile) {
+#ifdef _DEBUG
         std::cerr << "파일 열기 실패: " << NAND_FILE_PATH << '\n';
+#endif
         return entireData;
     }
 


### PR DESCRIPTION
ssd를 release 모드로  실행할 때, cout, cerr 등 화면에 출력하는것이 없도록 수정

cout, cerr 구문을
#ifdef _DEBUG #endif 로 묶어서
release 모드에서는 화면 출력이 없도록 수정