### PR TITLE
FastRead 구현

### DIFF
--- a/TeamBest_SSD/command_buffer.cpp
+++ b/TeamBest_SSD/command_buffer.cpp
@@ -1,4 +1,6 @@
 ﻿#include "command_buffer.h"
+#include "util.h"
+
 #include <string>
 #include <vector>
 #include <iostream>
@@ -26,7 +28,18 @@ std::vector<std::string> CommandBuffer::Flush() {
 	return {};
 }
 
-std::string CommandBuffer::FastRead() {
+std::string CommandBuffer::FastRead(int targetAddress) {
+	std::vector<std::string> commandsInBuffer = ReadBuffers();
+
+	for (const auto& command : commandsInBuffer) {
+		auto tokens = BEST_UTILS::StringTokenizer(command);
+		std::string command = tokens[COMMAND_PARAM_INDEX_WRITE::COMMAND_NAME];
+		int addressInCommand = std::stoi(tokens[COMMAND_PARAM_INDEX_WRITE::ADDRESS]);
+		if (command == WRITE_COMMAND_NAME && targetAddress == addressInCommand) {
+			return tokens[COMMAND_PARAM_INDEX_WRITE::VALUE];
+		}	
+	}
+
 	return {};
 }
 

--- a/TeamBest_SSD/command_buffer.h
+++ b/TeamBest_SSD/command_buffer.h
@@ -6,6 +6,21 @@
 #include <filesystem>
 #include <regex>
 
+namespace COMMAND_PARAM_INDEX_WRITE {
+	enum COMMAND_PARAM_INDEX_WRITE {
+		COMMAND_NAME = 0,
+		ADDRESS,
+		VALUE
+	};
+}
+
+namespace COMMAND_PARAM_INDEX_ERASE {
+	enum COMMAND_PARAM_INDEX_ERASE {
+		COMMAND_NAME = 0,
+		ADDRESS,
+		SIZE
+	};
+}
 
 class CommandBuffer{
 public:
@@ -14,7 +29,7 @@ public:
 
 	bool IsFull();
 	std::vector<std::string> Flush();
-	std::string FastRead();
+	std::string FastRead(int address);
 	void AppendCommand(const std::string& command);
 	std::vector<std::string> ReadBuffers();
 
@@ -50,6 +65,8 @@ private:
 	inline static const std::string BUFFER_DIR_PATH{ "buffer" };
 	inline static const std::string EMPTY_BUFFER_NAME{ "empty" };
 	inline static const std::string DELIMITER{ "_" };
+
+	inline static const std::string WRITE_COMMAND_NAME = { "W" };
 
 
 };

--- a/TeamBest_SSD/main.cpp
+++ b/TeamBest_SSD/main.cpp
@@ -13,7 +13,7 @@ int main(int argc, char* argv[])
 {
 #ifdef _DEBUG
     ::testing::InitGoogleMock();
-    //::testing::GTEST_FLAG(filter) = "TestCommandBuffer.*";
+    ::testing::GTEST_FLAG(filter) = "TestCommandBuffer.*";
     return RUN_ALL_TESTS();
 #else
     std::string ssdFefaultType{ "SSD" };

--- a/TeamBest_SSD/util.h
+++ b/TeamBest_SSD/util.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <algorithm>
 #include <cctype>
+#include <vector>
 
 namespace BEST_UTILS {
     inline std::string ToUpper(const std::string& input) {
@@ -10,5 +11,29 @@ namespace BEST_UTILS {
         std::transform(result.begin(), result.end(), result.begin(),
             [](unsigned char c) { return std::toupper(c); });
         return result;
+    }
+
+    inline std::vector<std::string> StringTokenizer(
+        const std::string& inStr, char delimiter = ' ') {
+        std::vector<std::string> tokens;
+        std::string token;
+
+        for (char ch : inStr) {
+            if (ch == delimiter) {
+                if (!token.empty()) {
+                    tokens.push_back(token);
+                    token.clear();
+                }
+            }
+            else {
+                token += ch;
+            }
+        }
+
+        if (!token.empty()) {
+            tokens.push_back(token);
+        }
+
+        return tokens;
     }
 }


### PR DESCRIPTION
ReadBuffers()로 버퍼를 읽고
반환된 값이 W 명령이면서 주소가 일치할 경우 buffer에 저장된 value를 반환

일치하지 않을 경우 빈문자열("")을 반환

테스트 케이스 실패, 성공 두가지 추가

테스트에서 중복되는 코드 함수로 추출
void RemoveDirectoryAndRecreate()
void MakeBufferFiles()


enum 변수 이름 충동 방지를 위해 
namespace 추가
namespace COMMAND_PARAM_INDEX_WRITE {
}

namespace COMMAND_PARAM_INDEX_ERASE {
}