### PR TITLE
Flush 기능 추가

### DIFF
--- a/TeamBest_SSD/TeamBest_SSD.vcxproj
+++ b/TeamBest_SSD/TeamBest_SSD.vcxproj
@@ -141,6 +141,7 @@
     <ClCompile Include="ssd_factory.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="TestCommandBuffer.cpp" />
+    <ClCompile Include="TestCommons.cpp" />
     <ClCompile Include="TestSSD.cpp" />
     <ClCompile Include="TestSSDController.cpp" />
     <ClCompile Include="TestSSDFactory.cpp" />
@@ -153,6 +154,7 @@
     <ClInclude Include="ssd.h" />
     <ClInclude Include="ssd_controller.h" />
     <ClInclude Include="ssd_factory.h" />
+    <ClInclude Include="TestCommons.h" />
     <ClInclude Include="util.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/TeamBest_SSD/TeamBest_SSD.vcxproj
+++ b/TeamBest_SSD/TeamBest_SSD.vcxproj
@@ -145,6 +145,7 @@
     <ClCompile Include="TestSSD.cpp" />
     <ClCompile Include="TestSSDController.cpp" />
     <ClCompile Include="TestSSDFactory.cpp" />
+    <ClCompile Include="TestTntegration.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/TeamBest_SSD/TeamBest_SSD.vcxproj.filters
+++ b/TeamBest_SSD/TeamBest_SSD.vcxproj.filters
@@ -51,6 +51,9 @@
     <ClCompile Include="TestCommandBuffer.cpp">
       <Filter>TEST</Filter>
     </ClCompile>
+    <ClCompile Include="TestCommons.cpp">
+      <Filter>TEST</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -70,6 +73,9 @@
     </ClInclude>
     <ClInclude Include="util.h">
       <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="TestCommons.h">
+      <Filter>TEST</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/TeamBest_SSD/TeamBest_SSD.vcxproj.filters
+++ b/TeamBest_SSD/TeamBest_SSD.vcxproj.filters
@@ -18,9 +18,6 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="TeamBest_SSD.cpp">
-      <Filter>소스 파일</Filter>
-    </ClCompile>
     <ClCompile Include="ssd.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
@@ -39,6 +36,21 @@
     <ClCompile Include="ssd_controller.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
+    <ClCompile Include="command_buffer.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="ssd_factory.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="main.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="TestSSDFactory.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="TestCommandBuffer.cpp">
+      <Filter>TEST</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -48,6 +60,15 @@
       <Filter>헤더 파일</Filter>
     </ClInclude>
     <ClInclude Include="ssd_controller.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="command_buffer.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="ssd_factory.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="util.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
   </ItemGroup>

--- a/TeamBest_SSD/TeamBest_SSD.vcxproj.filters
+++ b/TeamBest_SSD/TeamBest_SSD.vcxproj.filters
@@ -54,6 +54,9 @@
     <ClCompile Include="TestCommons.cpp">
       <Filter>TEST</Filter>
     </ClCompile>
+    <ClCompile Include="TestTntegration.cpp">
+      <Filter>TEST</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/TeamBest_SSD/TestCommandBuffer.cpp
+++ b/TeamBest_SSD/TestCommandBuffer.cpp
@@ -1,4 +1,5 @@
 ﻿#include "gmock/gmock.h"
+#include "TestCommons.h"
 #include "command_buffer.h"
 #include <iostream>
 #include <filesystem>
@@ -11,63 +12,10 @@
 using namespace testing;
 namespace fs = std::filesystem;
 
-
-int countFilesInBuffer() {
-	int count = 0;
-	for (const auto& entry : std::filesystem::directory_iterator("buffer")) {
-		if (std::filesystem::is_regular_file(entry)) {
-			++count;
-		}
-	}
-	return count;
-}
-
-std::vector<std::string> GetFilesInDirectory(const std::string& directoryPath) {
-	std::vector<std::string> fileList;
-
-	try {
-		if (fs::exists(directoryPath) && fs::is_directory(directoryPath)) {
-			for (const auto& entry : fs::directory_iterator(directoryPath)) {
-				if (fs::is_regular_file(entry.status())) {
-					fileList.push_back(entry.path().filename().string());
-				}
-			}
-		}
-	}
-	catch (const fs::filesystem_error& e) {
-#ifdef _DEBUG
-		std::cerr << "파일 목록 검사 중 오류 발생: " << e.what() << '\n';
-#endif
-	}
-
-	return fileList;
-
-}
-
-void RemoveDirectoryAndRecreate( const std::string& dirPath ) {
-	if (std::filesystem::exists(dirPath))
-		std::filesystem::remove_all(dirPath);
-
-	if (!fs::exists(dirPath)) {
-		fs::create_directory(dirPath);
-	}
-}
-
-void MakeBufferFiles(
-	const std::vector<std::string>& bufferNames, 
-	const std::string & bufferDirPath) {
-	for (const auto& bufferName : bufferNames) {
-		std::ofstream outFile(bufferDirPath + "/" + bufferName);
-		outFile.close();
-	}
-}
-
-
 TEST(TestCommandBuffer, ContructorTest) {
 	EXPECT_NO_THROW(std::shared_ptr<CommandBuffer> buffer 
 		= std::make_shared<CommandBuffer>());
 }
-
 
 TEST(TestCommandBuffer, BufferExistsAfterInit){
 	const std::string dirName = "buffer";

--- a/TeamBest_SSD/TestCommandBuffer.cpp
+++ b/TeamBest_SSD/TestCommandBuffer.cpp
@@ -290,3 +290,39 @@ TEST(TestCommandBuffer, TestFastReadWhenBufferAvailable) {
 	std::string expected{ "0x12345678" };
 	EXPECT_EQ(expected, value);
 }
+
+TEST(TestCommandBuffer, TestFlushWhenBufferEmpty) {
+	std::string BUFFER_DIR = "buffer";
+
+	RemoveDirectoryAndRecreate(BUFFER_DIR);
+
+	CommandBuffer buffers;	
+	std::vector<std::string> commandBuffers = buffers.Flush();
+
+	std::vector<std::string> expected{};
+	EXPECT_EQ(expected, commandBuffers);
+}
+
+TEST(TestCommandBuffer, TestFlushWhenBufferNotEmpty) {
+	std::string BUFFER_DIR = "buffer";
+
+	RemoveDirectoryAndRecreate(BUFFER_DIR);
+
+	std::vector<std::string> bufferNames = {
+		{"1_E 3 4"},
+		{"2_W 72 0x12345678" },
+		{"3_empty"},
+		{"4_empty"},
+		{"5_empty"}
+	};
+	MakeBufferFiles(bufferNames, BUFFER_DIR);
+
+	CommandBuffer buffers;
+	std::vector<std::string> commandBuffers = buffers.Flush();
+
+	std::vector<std::string> expected{
+		{"E 3 4"},
+		{"W 72 0x12345678" }
+	};
+	EXPECT_EQ(expected, commandBuffers);
+}

--- a/TeamBest_SSD/TestCommons.cpp
+++ b/TeamBest_SSD/TestCommons.cpp
@@ -18,6 +18,13 @@ void ClearFileContent(const std::string& path) {
 	file.close();
 }
 
+void RemoveFile(const std::string& path) {
+	if (fs::exists(path)) {
+		if (fs::remove(path)) {
+		}
+	}
+}
+
 std::string ReadFileContent(const std::string& path) {
 	std::ifstream file(path);
 	if (!file.is_open()) {

--- a/TeamBest_SSD/TestCommons.cpp
+++ b/TeamBest_SSD/TestCommons.cpp
@@ -1,0 +1,98 @@
+#include "TestCommons.h"
+
+#include <iostream>
+#include <filesystem>
+#include <fstream>
+#include <vector>
+#include <string>
+#include <algorithm>
+
+namespace fs = std::filesystem;
+
+void ClearFileContent(const std::string& path) {
+	std::ofstream file(path, std::ios::trunc);
+
+	if (!file.is_open()) {
+		throw std::runtime_error("파일을 열 수 없습니다: " + path);
+	}
+	file.close();
+}
+
+std::string ReadFileContent(const std::string& path) {
+	std::ifstream file(path);
+	if (!file.is_open()) {
+		throw std::runtime_error("파일을 열 수 없습니다: " + path);
+	}
+
+	std::string line;
+	std::getline(file, line);
+	file.close();
+
+	return line;
+}
+
+bool ContainsStringInFile(const std::string& filePath, const std::string& keyword) {
+	std::ifstream file(filePath);
+	if (!file.is_open()) {
+		throw std::runtime_error("파일을 열 수 없습니다: " + filePath);
+	}
+
+	std::string line;
+	while (std::getline(file, line)) {
+		if (line.find(keyword) != std::string::npos) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+int countFilesInBuffer() {
+	int count = 0;
+	for (const auto& entry : std::filesystem::directory_iterator("buffer")) {
+		if (std::filesystem::is_regular_file(entry)) {
+			++count;
+		}
+	}
+	return count;
+}
+
+std::vector<std::string> GetFilesInDirectory(const std::string& directoryPath) {
+	std::vector<std::string> fileList;
+
+	try {
+		if (fs::exists(directoryPath) && fs::is_directory(directoryPath)) {
+			for (const auto& entry : fs::directory_iterator(directoryPath)) {
+				if (fs::is_regular_file(entry.status())) {
+					fileList.push_back(entry.path().filename().string());
+				}
+			}
+		}
+	}
+	catch (const fs::filesystem_error& e) {
+#ifdef _DEBUG
+		std::cerr << "파일 목록 검사 중 오류 발생: " << e.what() << '\n';
+#endif
+	}
+
+	return fileList;
+
+}
+
+void RemoveDirectoryAndRecreate(const std::string& dirPath) {
+	if (std::filesystem::exists(dirPath))
+		std::filesystem::remove_all(dirPath);
+
+	if (!fs::exists(dirPath)) {
+		fs::create_directory(dirPath);
+	}
+}
+
+void MakeBufferFiles(
+	const std::vector<std::string>& bufferNames,
+	const std::string& bufferDirPath) {
+	for (const auto& bufferName : bufferNames) {
+		std::ofstream outFile(bufferDirPath + "/" + bufferName);
+		outFile.close();
+	}
+}

--- a/TeamBest_SSD/TestCommons.h
+++ b/TeamBest_SSD/TestCommons.h
@@ -4,6 +4,7 @@
 #include <vector>
 
 void ClearFileContent(const std::string& path);
+void RemoveFile(const std::string& path);
 std::string ReadFileContent(const std::string& path);
 bool ContainsStringInFile(const std::string& filePath, const std::string& keyword);
 int countFilesInBuffer();

--- a/TeamBest_SSD/TestCommons.h
+++ b/TeamBest_SSD/TestCommons.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+void ClearFileContent(const std::string& path);
+std::string ReadFileContent(const std::string& path);
+bool ContainsStringInFile(const std::string& filePath, const std::string& keyword);
+int countFilesInBuffer();
+std::vector<std::string> GetFilesInDirectory(const std::string& directoryPath);
+void RemoveDirectoryAndRecreate(const std::string& dirPath);
+void MakeBufferFiles(const std::vector<std::string>& bufferNames,
+	const std::string& bufferDirPath);

--- a/TeamBest_SSD/TestSSD.cpp
+++ b/TeamBest_SSD/TestSSD.cpp
@@ -1,4 +1,5 @@
 ﻿#include "gmock/gmock.h"
+#include "TestCommons.h"
 #include "ssd.h"
 
 #include <memory>
@@ -9,45 +10,6 @@
 #include <utility>
 
 using namespace testing;
-
-
-void ClearFileContent(const std::string& path) {
-    std::ofstream file(path, std::ios::trunc);
-
-    if (!file.is_open()) {
-        throw std::runtime_error("파일을 열 수 없습니다: " + path);
-    }
-    file.close();
-}
-
-std::string ReadFileContent(const std::string& path) {
-    std::ifstream file(path);
-    if (!file.is_open()) {
-        throw std::runtime_error("파일을 열 수 없습니다: " + path);
-    }
-
-    std::string line;
-    std::getline(file, line);
-    file.close();
-
-    return line;
-}
-
-bool ContainsStringInFile(const std::string& filePath, const std::string& keyword) {
-    std::ifstream file(filePath);
-    if (!file.is_open()) {
-        throw std::runtime_error("파일을 열 수 없습니다: " + filePath);
-    }
-
-    std::string line;
-    while (std::getline(file, line)) {
-        if (line.find(keyword) != std::string::npos) {
-            return true;
-        }
-    }
-
-    return false;
-}
 
 TEST(TestSSD, ContructorTest) {
 	EXPECT_NO_THROW(std::shared_ptr<SSD> ssd = std::make_shared<SSD>());

--- a/TeamBest_SSD/TestSSDController.cpp
+++ b/TeamBest_SSD/TestSSDController.cpp
@@ -1,6 +1,7 @@
 ﻿#include "gmock/gmock.h"
 #include "ssd_controller.h"
 #include "ssd.h"
+#include "command_buffer.h"
 
 #include <vector>
 #include <string>
@@ -8,6 +9,7 @@
 
 using namespace std;
 using namespace testing;
+namespace fs = std::filesystem;
 
 class MockSSD : public ISSD{
 public:
@@ -42,7 +44,10 @@ TEST(TestSSDController, InvalidParametersCount) {
 		"R",
 		"R 1 2 3",
 		"W",
-		"W 1 2 3 4"
+		"W 1 2 3 4",
+		"E",
+		"E 1 2 3 4",
+		"F 1 2"
 	};
 
 	std::shared_ptr<MockSSD> mockSSD = std::make_shared<MockSSD>();
@@ -91,5 +96,52 @@ TEST(TestSSDController, ValidWriteCommand) {
 
 	bool result = ssdController.Run(command);
 	EXPECT_EQ(true, result);
+}
+
+TEST(TestSSDController, ValidEraseCommand) {
+	std::shared_ptr<MockSSD> mockSSD = std::make_shared<MockSSD>();
+	SSDController ssdController{ mockSSD };
+
+	vector<string> commands = {
+		"E 1 5",
+		"e 1 5"
+	};
+
+	EXPECT_CALL(*mockSSD, Erase(1, 5)).Times(commands.size());
+	for (const auto& command : commands) {
+		bool result = ssdController.Run(command);
+		EXPECT_EQ(true, result);
+	}
+}
+
+TEST(TestSSDController, ValidFlushCommand) {
+	CommandBuffer buffer;
+	std::string BUFFER_DIR = "buffer";
+
+	if (std::filesystem::exists(BUFFER_DIR))
+		std::filesystem::remove_all(BUFFER_DIR);
+
+	if (!fs::exists(BUFFER_DIR)) {
+		fs::create_directory(BUFFER_DIR);
+	}
+	std::vector<std::string> bufferNames = {
+		{"1_W 0 0x12345678"},
+		{"2_E 3 4"},
+		{"3_W 1 0xABCDEF98"},
+		{"4_E 30 1"},
+		{"5_E 40 1"}
+	};
+	for (const auto& bufferName : bufferNames) {
+		std::ofstream outFile(BUFFER_DIR + "/" + bufferName);
+		outFile.close();
+	}
+
+	std::shared_ptr<MockSSD> mockSSD = std::make_shared<MockSSD>();	
 	
+	SSDController ssdController{ mockSSD };
+	string command = {"F"};
+
+	EXPECT_CALL(*mockSSD, Write(_, _)).Times(2);
+	EXPECT_CALL(*mockSSD, Erase(_, _)).Times(3);
+	ssdController.Run(command);
 }

--- a/TeamBest_SSD/TestTntegration.cpp
+++ b/TeamBest_SSD/TestTntegration.cpp
@@ -1,0 +1,100 @@
+#include "gmock/gmock.h"
+#include "TestCommons.h"
+
+#include "ssd.h"
+#include "command_buffer.h"
+#include "ssd_controller.h"
+
+using namespace std;
+namespace fs = std::filesystem;
+
+
+TEST(TestIntegration, FlushTestWhenWriteBufferExist) {
+	const std::string BUFFER_DIR = "buffer";
+	const std::string SSD_NAND_FILENAME = "ssd_nand.txt";
+	const std::string SSD_OUTPUT_FILENAME = "ssd_output.txt";
+
+	RemoveFile(SSD_NAND_FILENAME);
+	std::shared_ptr<ISSD> ssd = std::make_shared<SSD>();
+	SSDController ssdController{ ssd };
+
+	vector<string> writeParams = {
+		{"1 0x12345678" },
+		{"2 0xFAFAFAFA" },
+		{"3 0x1A2B3C3D" },
+		{"4 0x98765432" },
+		{"5 0x01020304" }
+	};
+	
+	std::vector<std::string> bufferNames = {
+		{"1_W 1 0x12345678" },
+		{"2_W 2 0xFAFAFAFA" },
+		{"3_W 3 0x1A2B3C3D" },
+		{"4_W 4 0x98765432" },
+		{"5_W 5 0x01020304" }
+	};
+	
+	for (const auto& expected : writeParams) {
+		EXPECT_EQ(false, ContainsStringInFile(SSD_NAND_FILENAME, expected));
+	}	
+
+	RemoveDirectoryAndRecreate(BUFFER_DIR);
+	MakeBufferFiles(bufferNames, BUFFER_DIR);
+		
+	ssdController.Run("F");
+	for (const auto& expected : writeParams) {
+		EXPECT_EQ(true, ContainsStringInFile(SSD_NAND_FILENAME, expected));
+	}
+}
+
+
+TEST(TestIntegration, FlushTestWhenEraseBufferExist) {
+	const std::string BUFFER_DIR = "buffer";
+	const std::string SSD_NAND_FILENAME = "ssd_nand.txt";
+	const std::string SSD_OUTPUT_FILENAME = "ssd_output.txt";
+
+	RemoveFile(SSD_NAND_FILENAME);
+	std::shared_ptr<ISSD> ssd = std::make_shared<SSD>();
+	SSDController ssdController{ ssd };
+
+	vector<string> writeParams = {
+		{"1 0x12345678" },
+		{"2 0xFAFAFAFA" },
+		{"3 0x1A2B3C3D" },
+		{"4 0x98765432" },
+		{"5 0x01020304" }
+	};
+
+	std::vector<std::string> wirteBufferNames = {
+		{"1_W 1 0x12345678" },
+		{"2_W 2 0xFAFAFAFA" },
+		{"3_W 3 0x1A2B3C3D" },
+		{"4_W 4 0x98765432" },
+		{"5_W 5 0x01020304" }
+	};
+
+	RemoveDirectoryAndRecreate(BUFFER_DIR);
+	MakeBufferFiles(wirteBufferNames, BUFFER_DIR);
+	
+	ssdController.Run("F");
+	for (const auto& expected : writeParams) {
+		EXPECT_EQ(true, ContainsStringInFile(SSD_NAND_FILENAME, expected));
+	}
+
+	std::vector<std::string> eraseBufferNames = {
+		{"1_E 1 1" },
+		{"2_W 2 0xFAFAFAFA" },
+		{"3_E 3 1" },
+		{"4_W 4 0x98765432" },
+		{"5_E 5 1" }
+	};
+	RemoveDirectoryAndRecreate(BUFFER_DIR);
+	MakeBufferFiles(eraseBufferNames, BUFFER_DIR);
+	
+	ssdController.Run("F");
+	for (int i = 0; i < writeParams.size(); ++i) {
+		bool answer = false;
+		if(i%2 == 1) answer = true;
+		EXPECT_EQ(answer, ContainsStringInFile(SSD_NAND_FILENAME, writeParams[i]));
+	}
+}

--- a/TeamBest_SSD/command_buffer.cpp
+++ b/TeamBest_SSD/command_buffer.cpp
@@ -17,7 +17,11 @@ bool CommandBuffer::IsFull() {
 }
 
 std::vector<std::string> CommandBuffer::Flush() {
-	return {};
+	std::vector<std::string> commandBuffers = ReadBuffers();
+	RemoveBufferDirectory();
+	InitBuffers();
+
+	return commandBuffers;
 }
 
 std::string CommandBuffer::FastRead(int targetAddress) {

--- a/TeamBest_SSD/command_buffer.h
+++ b/TeamBest_SSD/command_buffer.h
@@ -54,6 +54,7 @@ private:
 	std::string GetBufferIndexAtBufferName(const std::string& bufferName);
 	std::string MakeCommandFromFile(const std::filesystem::directory_entry& file);
 	std::string removeIndex(const std::string& fileName);
+	void RemoveBufferDirectory();
 
 
 private:
@@ -91,4 +92,8 @@ inline std::string CommandBuffer::GetBufferIndexAtBufferName(const std::string& 
 		return bufferName.substr(0, pos + 1);
 	}
 	return "";		
+}
+
+inline void CommandBuffer::RemoveBufferDirectory() {
+	std::filesystem::remove_all(BUFFER_DIR_PATH);
 }

--- a/TeamBest_SSD/main.cpp
+++ b/TeamBest_SSD/main.cpp
@@ -13,7 +13,7 @@ int main(int argc, char* argv[])
 {
 #ifdef _DEBUG
     ::testing::InitGoogleMock();
-    ::testing::GTEST_FLAG(filter) = "TestCommandBuffer.*";
+    //::testing::GTEST_FLAG(filter) = "TestCommandBuffer.*";
     return RUN_ALL_TESTS();
 #else
     std::string ssdFefaultType{ "SSD" };

--- a/TeamBest_SSD/main.cpp
+++ b/TeamBest_SSD/main.cpp
@@ -13,7 +13,7 @@ int main(int argc, char* argv[])
 {
 #ifdef _DEBUG
     ::testing::InitGoogleMock();
-    //::testing::GTEST_FLAG(filter) = "TestCommandBuffer.*";
+    ::testing::GTEST_FLAG(filter) = "TestIntegration.*";
     return RUN_ALL_TESTS();
 #else
     std::string ssdFefaultType{ "SSD" };

--- a/TeamBest_SSD/ssd_controller.cpp
+++ b/TeamBest_SSD/ssd_controller.cpp
@@ -4,67 +4,57 @@
 
 SSDController::SSDController(std::shared_ptr<ISSD> ssdExecutor)
     : ssd{ ssdExecutor } {
+    cmdBuffers = std::make_shared<CommandBuffer>();
 }
 
 
 bool SSDController::Run(const std::string& command) {
-	std::vector<std::string> tokens = CommandParser(command);
-    ConvertCommandToUpperCase(tokens[SSD_COMMAND_PARAM_INDEX::COMMAND_NAME]);
+	std::vector<std::string> tokens = BEST_UTILS::StringTokenizer(command);
+    ConvertCommandToUpperCase(tokens[SSD_COMMAND_PARAM_INDEX::COMMAND]);
     if (!IsValidCommand(tokens)) return false;
 
     Execute(tokens);
     return true;
 }
 
-std::vector<std::string> SSDController::CommandParser(
-	const std::string& command, char delimiter) {
-    std::vector<std::string> tokens;
-    std::string token;
-
-    for (char ch : command) {
-        if (ch == delimiter) {
-            if (!token.empty()) {
-                tokens.push_back(token);
-                token.clear();
-            }
-        }
-        else {
-            token += ch;
-        }
-    }
-
-    if (!token.empty()) {
-        tokens.push_back(token);
-    }
-
-    return tokens;
-}
-
 bool SSDController::IsValidCommand(const std::vector<std::string>& commandTokens) {
     const std::string& commandName = 
-        BEST_UTILS::ToUpper(commandTokens[SSD_COMMAND_PARAM_INDEX::COMMAND_NAME]);
-    if (commandName != READ_COMMAND_NAME &&
-        commandName != WRITE_COMMAND_NAME ) return false;
+        BEST_UTILS::ToUpper(commandTokens[SSD_COMMAND_PARAM_INDEX::COMMAND]);
+
+    if (!IsSupportedCommandName(commandName)) return false;
 
     size_t commandParamCount = commandTokens.size() - 1;
-    if (commandName == READ_COMMAND_NAME
-        && commandParamCount != READ_COMMAND_PARAM_COUNT) return false;
-
-    if (commandName == WRITE_COMMAND_NAME
-        && commandParamCount != WRITE_COMMAND_PARAM_COUNT) return false;
+    for (size_t i = 0; i < VALID_COMMAND_LIST.size(); ++i) {
+        if (commandName == VALID_COMMAND_LIST[i]
+            && commandParamCount != COMMAND_PRAM_COUNT[i]) return false;
+    }
 
     return true;
 }
 
 void SSDController::Execute(const std::vector<std::string>& commandTokens) {
     const std::string& commandName 
-        = commandTokens[SSD_COMMAND_PARAM_INDEX::COMMAND_NAME];
-    if (commandName == READ_COMMAND_NAME) {
+        = commandTokens[SSD_COMMAND_PARAM_INDEX::COMMAND];
+
+    if (commandName == VALID_COMMAND_LIST[SSD_COMMAND_TYPES::READ]) {
         ssd->Read(std::stoi(commandTokens[SSD_COMMAND_PARAM_INDEX::ADDRESS]));
     }
-    else if (commandName == WRITE_COMMAND_NAME) {
+    else if (commandName == VALID_COMMAND_LIST[SSD_COMMAND_TYPES::WRITE]) {
         ssd->Write(std::stoi(commandTokens[SSD_COMMAND_PARAM_INDEX::ADDRESS]),
                    commandTokens[SSD_COMMAND_PARAM_INDEX::VALUE]);
+    }
+    else if (commandName == VALID_COMMAND_LIST[SSD_COMMAND_TYPES::ERASE]) {
+        ssd->Erase(std::stoi(commandTokens[SSD_COMMAND_PARAM_INDEX::ADDRESS]),
+            std::stoi(commandTokens[SSD_COMMAND_PARAM_INDEX::SIZE]));
+    }
+    else if (commandName == VALID_COMMAND_LIST[SSD_COMMAND_TYPES::FLUSH]) {
+        std::vector<std::string> commandInBuffers = cmdBuffers->Flush();
+        for (const auto& command : commandInBuffers) {
+#ifdef _DEBUG
+            std::cout << "Command In Buffers : " << command << std::endl;
+#endif
+            Run(command);
+        }
     }
 }
 

--- a/TeamBest_SSD/ssd_controller.h
+++ b/TeamBest_SSD/ssd_controller.h
@@ -4,13 +4,24 @@
 #include <memory>
 
 #include "ssd.h"
+#include "command_buffer.h"
 #include "util.h"
 
-enum SSD_COMMAND_PARAM_INDEX {
-	COMMAND_NAME = 0,
-	ADDRESS,
-	VALUE
-};
+namespace SSD_COMMAND_TYPES {
+	enum SSD_COMMAND_TYPES {
+		READ = 0,
+		WRITE,
+		ERASE,
+		FLUSH
+	};
+}
+
+namespace SSD_COMMAND_PARAM_INDEX {
+	constexpr int COMMAND = 0;
+	constexpr int ADDRESS = 1;
+	constexpr int VALUE = 2;
+	constexpr int SIZE = 2;
+}
 
 class SSDController{
 public:
@@ -18,19 +29,28 @@ public:
 	bool Run(const std::string& command);
 
 private:
-	std::vector<std::string> CommandParser(const std::string& command, char delimiter = ' ');
 	bool IsValidCommand(const std::vector<std::string>& commandTokens);
 	void Execute(const std::vector<std::string>& commandTokens);	
 	void SetExecutor(std::shared_ptr<ISSD> ssdExecutor);
 	void ConvertCommandToUpperCase(std::string & command);
+	bool IsSupportedCommandName(const std::string& command);
 
 private:
 	std::shared_ptr<ISSD> ssd;
+	std::shared_ptr<CommandBuffer> cmdBuffers;
 
-	inline static const std::string READ_COMMAND_NAME = {"R"};
-	inline static const std::string WRITE_COMMAND_NAME = { "W" };
-	static constexpr size_t READ_COMMAND_PARAM_COUNT = 1;
-	static constexpr size_t WRITE_COMMAND_PARAM_COUNT = 2;
+	inline static const std::vector<std::string> VALID_COMMAND_LIST = {
+		{"R"},
+		{"W"},
+		{"E"},
+		{"F"}
+	};
+	inline static const std::vector<size_t> COMMAND_PRAM_COUNT = {
+		1,
+		2,
+		2,
+		0
+	};
 };
 
 inline void SSDController::SetExecutor(std::shared_ptr<ISSD> ssdExecutor) {
@@ -39,4 +59,9 @@ inline void SSDController::SetExecutor(std::shared_ptr<ISSD> ssdExecutor) {
 
 inline void SSDController::ConvertCommandToUpperCase(std::string& command) {
 	command = BEST_UTILS::ToUpper(command);
+}
+
+inline bool SSDController::IsSupportedCommandName(const std::string& command) {
+	return std::find(VALID_COMMAND_LIST.begin(), VALID_COMMAND_LIST.end(), command) 
+		!= VALID_COMMAND_LIST.end();
 }


### PR DESCRIPTION
Flush 기능 추가를 위해

CommandBuffer::Flush() 를 구현하고
SSDContoller에서 flush('F'), erase('E') 명령을 처리하도록 수정

테스트를 위해
공통으로 사용 가능한 테스트용 일반 함수를 TestCommons.h/.cpp로 옮김

SSDController, Command, SSD 명령을 통합 테스트하기 위한 TestIntegration.cpp를 추가하고
Flush 명령 테스트 두가지 개발
1. buffer에 W 명령을 5개 만든 후, flush 수행
2. 1번 과정을 수행 후, E 명령 3개를 만든 후 flush 수행


... 너무 많은 코드 변경을 한번의 PR에 올려 송구합니다.
