### PR TITLE
[Feature]ssdcontroller commandbuffer 통합

### DIFF
--- a/TeamBest_SSD/TestCommons.cpp
+++ b/TeamBest_SSD/TestCommons.cpp
@@ -1,4 +1,4 @@
-#include "TestCommons.h"
+ï»¿#include "TestCommons.h"
 
 #include <iostream>
 #include <filesystem>
@@ -13,7 +13,7 @@ void ClearFileContent(const std::string& path) {
 	std::ofstream file(path, std::ios::trunc);
 
 	if (!file.is_open()) {
-		throw std::runtime_error("ÆÄÀÏÀ» ¿­ ¼ö ¾ø½À´Ï´Ù: " + path);
+		throw std::runtime_error("íŒŒì¼ì„ ì—´ ìˆ˜ ì—†ìŠµë‹ˆë‹¤: " + path);
 	}
 	file.close();
 }
@@ -28,7 +28,7 @@ void RemoveFile(const std::string& path) {
 std::string ReadFileContent(const std::string& path) {
 	std::ifstream file(path);
 	if (!file.is_open()) {
-		throw std::runtime_error("ÆÄÀÏÀ» ¿­ ¼ö ¾ø½À´Ï´Ù: " + path);
+		throw std::runtime_error("íŒŒì¼ì„ ì—´ ìˆ˜ ì—†ìŠµë‹ˆë‹¤: " + path);
 	}
 
 	std::string line;
@@ -41,7 +41,7 @@ std::string ReadFileContent(const std::string& path) {
 bool ContainsStringInFile(const std::string& filePath, const std::string& keyword) {
 	std::ifstream file(filePath);
 	if (!file.is_open()) {
-		throw std::runtime_error("ÆÄÀÏÀ» ¿­ ¼ö ¾ø½À´Ï´Ù: " + filePath);
+		throw std::runtime_error("íŒŒì¼ì„ ì—´ ìˆ˜ ì—†ìŠµë‹ˆë‹¤: " + filePath);
 	}
 
 	std::string line;
@@ -78,7 +78,7 @@ std::vector<std::string> GetFilesInDirectory(const std::string& directoryPath) {
 	}
 	catch (const fs::filesystem_error& e) {
 #ifdef _DEBUG
-		std::cerr << "ÆÄÀÏ ¸ñ·Ï °Ë»ç Áß ¿À·ù ¹ß»ı: " << e.what() << '\n';
+		std::cerr << "íŒŒì¼ ëª©ë¡ ê²€ì‚¬ ì¤‘ ì˜¤ë¥˜ ë°œìƒ: " << e.what() << '\n';
 #endif
 	}
 

--- a/TeamBest_SSD/TestCommons.h
+++ b/TeamBest_SSD/TestCommons.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <string>
 #include <vector>

--- a/TeamBest_SSD/TestTntegration.cpp
+++ b/TeamBest_SSD/TestTntegration.cpp
@@ -5,6 +5,8 @@
 #include "command_buffer.h"
 #include "ssd_controller.h"
 
+#include<utility>
+
 using namespace std;
 namespace fs = std::filesystem;
 
@@ -96,5 +98,151 @@ TEST(TestIntegration, FlushTestWhenEraseBufferExist) {
 		bool answer = false;
 		if(i%2 == 1) answer = true;
 		EXPECT_EQ(answer, ContainsStringInFile(SSD_NAND_FILENAME, writeParams[i]));
+	}
+}
+
+TEST(TestIntegration, ReadTestWhenFastReadPossible) {
+	const std::string BUFFER_DIR = "buffer";
+	const std::string SSD_NAND_FILENAME = "ssd_nand.txt";
+	const std::string SSD_OUTPUT_FILENAME = "ssd_output.txt";
+
+	RemoveFile(SSD_NAND_FILENAME);
+	std::shared_ptr<ISSD> ssd = std::make_shared<SSD>();
+	SSDController ssdController{ ssd };
+
+	vector<string> writeParams = {
+		{"1 0x12345678" },
+		{"2 0xFAFAFAFA" },
+		{"3 0x1A2B3C3D" },
+		{"4 0x98765432" },
+		{"5 0x01020304" }
+	};
+
+	std::vector<std::string> wirteBufferNames = {
+		{"1_W 1 0x12345678" },
+		{"2_W 2 0xFAFAFAFA" },
+		{"3_W 3 0x1A2B3C3D" },
+		{"4_W 4 0x98765432" },
+		{"5_W 5 0x01020304" }
+	};
+
+	RemoveDirectoryAndRecreate(BUFFER_DIR);
+	MakeBufferFiles(wirteBufferNames, BUFFER_DIR);
+
+	vector<pair<int, string>> expectedResults = {
+		{1, "0x12345678" },
+		{2, "0xFAFAFAFA" },
+		{3, "0x1A2B3C3D" },
+		{4, "0x98765432" },
+		{5, "0x01020304" }
+	};
+
+	for (const auto [index, expected] : expectedResults) {
+		string cmd = "R " + to_string(index);
+		ssdController.Run(cmd);
+		EXPECT_EQ(expected, ReadFileContent(SSD_OUTPUT_FILENAME));
+	}
+}
+
+TEST(TestIntegration, ReadTestWhenFastReadImpossible) {
+	const std::string BUFFER_DIR = "buffer";
+	const std::string SSD_NAND_FILENAME = "ssd_nand.txt";
+	const std::string SSD_OUTPUT_FILENAME = "ssd_output.txt";
+
+	RemoveFile(SSD_NAND_FILENAME);
+	std::shared_ptr<ISSD> ssd = std::make_shared<SSD>();
+	SSDController ssdController{ ssd };
+
+	vector<string> writeParams = {
+		{"1 0x12345678" },
+		{"2 0xFAFAFAFA" },
+		{"3 0x1A2B3C3D" },
+		{"4 0x98765432" },
+		{"5 0x01020304" }
+	};
+
+	std::vector<std::string> wirteBufferNames = {
+		{"1_W 1 0x12345678" },
+		{"2_W 2 0xFAFAFAFA" },
+		{"3_W 3 0x1A2B3C3D" },
+		{"4_W 4 0x98765432" },
+		{"5_W 5 0x01020304" }
+	};
+
+	RemoveDirectoryAndRecreate(BUFFER_DIR);
+	MakeBufferFiles(wirteBufferNames, BUFFER_DIR);
+
+	vector<pair<int, string>> expectedResults = {
+		{11, "0x00000000" },
+		{21, "0x00000000" },
+		{31, "0x00000000" },
+		{41, "0x00000000" },
+		{51, "0x00000000" }
+	};
+
+	for (const auto [index, expected] : expectedResults) {
+		string command = "R " + to_string(index);
+		ssdController.Run(command);
+		EXPECT_EQ(expected, ReadFileContent(SSD_OUTPUT_FILENAME));
+	}
+}
+
+TEST(TestIntegration, ReadTestWithPartialFastRead) {
+	const std::string BUFFER_DIR = "buffer";
+	const std::string SSD_NAND_FILENAME = "ssd_nand.txt";
+	const std::string SSD_OUTPUT_FILENAME = "ssd_output.txt";
+
+	RemoveFile(SSD_NAND_FILENAME);
+	std::shared_ptr<ISSD> ssd = std::make_shared<SSD>();
+	SSDController ssdController{ ssd };
+
+	vector<string> writeParams = {
+		{"1 0x12345678" },
+		{"2 0xFAFAFAFA" },
+		{"3 0x1A2B3C3D" },
+		{"4 0x98765432" },
+		{"5 0x01020304" }
+	};
+
+	std::vector<std::string> wirteBufferNames = {
+		{"1_W 1 0x12345678" },
+		{"2_W 2 0xFAFAFAFA" },
+		{"3_W 3 0x1A2B3C3D" },
+		{"4_W 4 0x98765432" },
+		{"5_W 5 0x01020304" }
+	};
+
+	RemoveDirectoryAndRecreate(BUFFER_DIR);
+	MakeBufferFiles(wirteBufferNames, BUFFER_DIR);
+
+	vector<string> writeCommands = {
+		{"W 11 0xAA345678" },
+		{"W 21 0xBBFAFAFA" },
+		{"W 31 0xCC2B3C3D" },
+		{"W 41 0xDD765432" },
+		{"W 51 0xEE020304" }
+	};
+	for (const auto& command : writeCommands) {
+		ssdController.Run(command);
+	}
+
+
+	vector<pair<int, string>> expectedResults = {
+		{1, "0x12345678" },
+		{2, "0xFAFAFAFA" },
+		{3, "0x1A2B3C3D" },
+		{4, "0x98765432" },
+		{5, "0x01020304" },
+		{11, "0xAA345678" },
+		{21, "0xBBFAFAFA" },
+		{31, "0xCC2B3C3D" },
+		{41, "0xDD765432" },
+		{51, "0xEE020304" }
+	};
+
+	for (const auto [index, expected] : expectedResults) {
+		string cmd = "R " + to_string(index);
+		ssdController.Run(cmd);
+		EXPECT_EQ(expected, ReadFileContent(SSD_OUTPUT_FILENAME));
 	}
 }

--- a/TeamBest_SSD/command_buffer.cpp
+++ b/TeamBest_SSD/command_buffer.cpp
@@ -109,10 +109,6 @@ void CommandBuffer::AppendCommand(const std::string& command) {
 	if (IsFull()) return;
 	std::string emptyBuffer = GetFirstEmptyBuffer();
 
-#ifdef _DEBUG
-	std::cout << "Empty Buffer : " << emptyBuffer << std::endl;
-#endif
-
 	WriteCommandToBuffer(emptyBuffer, command);
 }
 

--- a/TeamBest_SSD/main.cpp
+++ b/TeamBest_SSD/main.cpp
@@ -13,7 +13,7 @@ int main(int argc, char* argv[])
 {
 #ifdef _DEBUG
     ::testing::InitGoogleMock();
-    ::testing::GTEST_FLAG(filter) = "TestCommandBuffer.*";
+    //::testing::GTEST_FLAG(filter) = "TestIntegration.*";
     return RUN_ALL_TESTS();
 #else
     std::string ssdFefaultType{ "SSD" };

--- a/TeamBest_SSD/ssd_controller.cpp
+++ b/TeamBest_SSD/ssd_controller.cpp
@@ -46,7 +46,7 @@ void SSDController::Execute(const std::vector<std::string>& commandTokens) {
         ExcuteEraseCommand(commandTokens);
     }
     else if (commandName == VALID_COMMAND_LIST[SSD_COMMAND_TYPES::FLUSH]) {
-        ExcuteFlushCommand(commandTokens);
+        ExcuteFlushCommand();
     }
 }
 
@@ -65,17 +65,28 @@ void SSDController::ExcuteWriteCommand(const std::vector<std::string>& commandTo
     ssd->Write(std::stoi(commandTokens[SSD_COMMAND_PARAM_INDEX::ADDRESS]),
         commandTokens[SSD_COMMAND_PARAM_INDEX::VALUE]);
 }
+
 void SSDController::ExcuteEraseCommand(const std::vector<std::string>& commandTokens) {
     ssd->Erase(std::stoi(commandTokens[SSD_COMMAND_PARAM_INDEX::ADDRESS]),
         std::stoi(commandTokens[SSD_COMMAND_PARAM_INDEX::SIZE]));
 }
-void SSDController::ExcuteFlushCommand(const std::vector<std::string>& commandTokens) {
+
+void SSDController::ExcuteFlushCommand() {
     std::vector<std::string> commandInBuffers = cmdBuffers->Flush();
     for (const auto& command : commandInBuffers) {
-#ifdef _DEBUG
-        std::cout << "Command In Buffers : " << command << std::endl;
-#endif
-        Run(command);
+
+        std::vector<std::string> commandTokens = BEST_UTILS::StringTokenizer(command);
+        const std::string& commandName
+            = commandTokens[SSD_COMMAND_PARAM_INDEX::COMMAND];
+
+       if (commandName == VALID_COMMAND_LIST[SSD_COMMAND_TYPES::WRITE]) {
+           ssd->Write(std::stoi(commandTokens[SSD_COMMAND_PARAM_INDEX::ADDRESS]),
+               commandTokens[SSD_COMMAND_PARAM_INDEX::VALUE]);
+        }
+        else if (commandName == VALID_COMMAND_LIST[SSD_COMMAND_TYPES::ERASE]) {
+           ssd->Erase(std::stoi(commandTokens[SSD_COMMAND_PARAM_INDEX::ADDRESS]),
+               std::stoi(commandTokens[SSD_COMMAND_PARAM_INDEX::SIZE]));
+        }
     }
 }
 

--- a/TeamBest_SSD/ssd_controller.cpp
+++ b/TeamBest_SSD/ssd_controller.cpp
@@ -8,12 +8,14 @@ SSDController::SSDController(std::shared_ptr<ISSD> ssdExecutor)
 }
 
 
-bool SSDController::Run(const std::string& command) {
+bool SSDController::Run(const std::string& orgCommand) {
+    std::string command = orgCommand;
+    ConvertFirstLetterToUpperCase(command);
 	std::vector<std::string> tokens = BEST_UTILS::StringTokenizer(command);
-    ConvertCommandToUpperCase(tokens[SSD_COMMAND_PARAM_INDEX::COMMAND]);
+    
     if (!IsValidCommand(tokens)) return false;
 
-    Execute(tokens);
+    Execute(tokens, command);
     return true;
 }
 
@@ -32,7 +34,9 @@ bool SSDController::IsValidCommand(const std::vector<std::string>& commandTokens
     return true;
 }
 
-void SSDController::Execute(const std::vector<std::string>& commandTokens) {
+void SSDController::Execute(
+    const std::vector<std::string>& commandTokens,
+    const std::string& originCommand) {
     const std::string& commandName 
         = commandTokens[SSD_COMMAND_PARAM_INDEX::COMMAND];
 
@@ -40,10 +44,10 @@ void SSDController::Execute(const std::vector<std::string>& commandTokens) {
         ExcuteReadCommand(commandTokens);        
     }
     else if (commandName == VALID_COMMAND_LIST[SSD_COMMAND_TYPES::WRITE]) {
-        ExcuteWriteCommand(commandTokens);
+        ExcuteWriteCommand(commandTokens, originCommand);
     }
     else if (commandName == VALID_COMMAND_LIST[SSD_COMMAND_TYPES::ERASE]) {
-        ExcuteEraseCommand(commandTokens);
+        ExcuteEraseCommand(commandTokens, originCommand);
     }
     else if (commandName == VALID_COMMAND_LIST[SSD_COMMAND_TYPES::FLUSH]) {
         ExcuteFlushCommand();
@@ -61,14 +65,22 @@ void SSDController::ExcuteReadCommand(const std::vector<std::string>& commandTok
     }
 }
 
-void SSDController::ExcuteWriteCommand(const std::vector<std::string>& commandTokens) {
-    ssd->Write(std::stoi(commandTokens[SSD_COMMAND_PARAM_INDEX::ADDRESS]),
-        commandTokens[SSD_COMMAND_PARAM_INDEX::VALUE]);
+void SSDController::ExcuteWriteCommand(
+    const std::vector<std::string>& commandTokens,
+    const std::string& originCommand) {
+    if (cmdBuffers->IsFull()) {
+        ExcuteFlushCommand();
+    }
+    cmdBuffers->AppendCommand(originCommand);
 }
 
-void SSDController::ExcuteEraseCommand(const std::vector<std::string>& commandTokens) {
-    ssd->Erase(std::stoi(commandTokens[SSD_COMMAND_PARAM_INDEX::ADDRESS]),
-        std::stoi(commandTokens[SSD_COMMAND_PARAM_INDEX::SIZE]));
+void SSDController::ExcuteEraseCommand(
+    const std::vector<std::string>& commandTokens,
+    const std::string& originCommand) {
+    if (cmdBuffers->IsFull()) {
+        ExcuteFlushCommand();
+    }
+    cmdBuffers->AppendCommand(originCommand);
 }
 
 void SSDController::ExcuteFlushCommand() {

--- a/TeamBest_SSD/ssd_controller.h
+++ b/TeamBest_SSD/ssd_controller.h
@@ -38,7 +38,7 @@ private:
 	void ExcuteReadCommand(const std::vector<std::string>& commandTokens);
 	void ExcuteWriteCommand(const std::vector<std::string>& commandTokens);
 	void ExcuteEraseCommand(const std::vector<std::string>& commandTokens);
-	void ExcuteFlushCommand(const std::vector<std::string>& commandTokens);
+	void ExcuteFlushCommand();
 
 private:
 	std::shared_ptr<ISSD> ssd;

--- a/TeamBest_SSD/ssd_controller.h
+++ b/TeamBest_SSD/ssd_controller.h
@@ -30,14 +30,21 @@ public:
 
 private:
 	bool IsValidCommand(const std::vector<std::string>& commandTokens);
-	void Execute(const std::vector<std::string>& commandTokens);	
+	void Execute(
+		const std::vector<std::string>& commandTokens,
+		const std::string & originCommand);	
 	void SetExecutor(std::shared_ptr<ISSD> ssdExecutor);
 	void ConvertCommandToUpperCase(std::string & command);
+	void ConvertFirstLetterToUpperCase(std::string& command);
 	bool IsSupportedCommandName(const std::string& command);
 
 	void ExcuteReadCommand(const std::vector<std::string>& commandTokens);
-	void ExcuteWriteCommand(const std::vector<std::string>& commandTokens);
-	void ExcuteEraseCommand(const std::vector<std::string>& commandTokens);
+	void ExcuteWriteCommand(
+		const std::vector<std::string>& commandTokens,
+		const std::string& originCommand);
+	void ExcuteEraseCommand(
+		const std::vector<std::string>& commandTokens,
+		const std::string& originCommand);
 	void ExcuteFlushCommand();
 
 private:
@@ -64,6 +71,10 @@ inline void SSDController::SetExecutor(std::shared_ptr<ISSD> ssdExecutor) {
 
 inline void SSDController::ConvertCommandToUpperCase(std::string& command) {
 	command = BEST_UTILS::ToUpper(command);
+}
+
+inline void SSDController::ConvertFirstLetterToUpperCase(std::string& command){
+	if(!command.empty()) BEST_UTILS::ToUpper(command[0]);
 }
 
 inline bool SSDController::IsSupportedCommandName(const std::string& command) {

--- a/TeamBest_SSD/util.h
+++ b/TeamBest_SSD/util.h
@@ -6,6 +6,10 @@
 #include <vector>
 
 namespace BEST_UTILS {
+    inline void ToUpper(char & input) {
+        input = std::toupper(input);
+    }
+
     inline std::string ToUpper(const std::string& input) {
         std::string result = input;
         std::transform(result.begin(), result.end(), result.begin(),


### PR DESCRIPTION
SSDController와 CommandBuffer, SSD가 연동 되도록 코드를 구현하였습니다.

코드 수정에 따른 기존 테스트 코드 수정 및
통합 테스트 코드 추가하였습니다.

SSDController::Run 함수를 시작 점으로 해서 보시면 흐름 파악에 도움이 될 것 같습니다.
R, F 명령은 직접 ssd의 함수를 호출하고
W, E 명령은 CommandBuffer를 사용하도록 하였습니다.

검증
[V] Build
[V] Regression Test Pass
[V] 해당 기능 TC