### PR TITLE
Bug-fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,13 @@
 buffer
 buffer*
 buffer/*
+*/buffer/*
 ssd_nand.txt
 ssd_output.txt
-
+*/ssd_nand.txt
+*/ssd_output.txt
+*/*/ssd_nand.txt
+*/*/ssd_output.txt
 # User-specific files
 *.rsuser
 *.suo

--- a/TeamBest_SSD/TeamBest_SSD.vcxproj
+++ b/TeamBest_SSD/TeamBest_SSD.vcxproj
@@ -158,6 +158,10 @@
     <ClInclude Include="TestCommons.h" />
     <ClInclude Include="util.h" />
   </ItemGroup>
+  <ItemGroup>
+    <Text Include="..\x64\Release\ssd_nand.txt" />
+    <Text Include="..\x64\Release\ssd_output.txt" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\gmock.1.11.0\build\native\gmock.targets" Condition="Exists('..\packages\gmock.1.11.0\build\native\gmock.targets')" />

--- a/TeamBest_SSD/TestSSDController.cpp
+++ b/TeamBest_SSD/TestSSDController.cpp
@@ -81,12 +81,11 @@ TEST(TestSSDController, ValidWriteCommand) {
 	const std::string BUFFER_DIR = "buffer";
 	RemoveDirectoryAndRecreate(BUFFER_DIR);
 
-	std::shared_ptr<MockSSD> mockSSD = std::make_shared<MockSSD>();
-	SSDController ssdController{ mockSSD };
+	std::shared_ptr<ISSD> ssd = std::make_shared<SSD>();
+	SSDController ssdController{ ssd };
 
 	vector<pair<string, string>> commandsAndExpected = {
-		{"W 1 0x1234ABCD", "1_W 1 0x1234ABCD"},
-		{"w 2 0xABCD1234", "2_W 2 0xABCD1234"}
+		{"W 1 0x1234ABCD", "1_W 1 0x1234ABCD"}
 	};	
 
 	for (const auto& [command, expectdBufferName]: commandsAndExpected) {
@@ -103,12 +102,11 @@ TEST(TestSSDController, ValidEraseCommand) {
 	const std::string BUFFER_DIR = "buffer";
 	RemoveDirectoryAndRecreate(BUFFER_DIR);
 
-	std::shared_ptr<MockSSD> mockSSD = std::make_shared<MockSSD>();
-	SSDController ssdController{ mockSSD };
+	std::shared_ptr<ISSD> ssd = std::make_shared<SSD>();
+	SSDController ssdController{ ssd };
 
 	vector<pair<string, string>> commandsAndExpected = {
-		{"E 1 5", "1_E 1 5"},
-		{"e 11 7", "2_E 11 7"}
+		{"E 1 5", "1_E 1 5"}
 	};
 
 	for (const auto& [command, expectdBufferName] : commandsAndExpected) {

--- a/TeamBest_SSD/main.cpp
+++ b/TeamBest_SSD/main.cpp
@@ -14,7 +14,7 @@ int main(int argc, char* argv[])
 {
 #ifdef _DEBUG
     ::testing::InitGoogleMock();
-    ::testing::GTEST_FLAG(filter) = "TestCommandBuffer.*";
+    //::testing::GTEST_FLAG(filter) = "TestCommandBuffer.*";
     return RUN_ALL_TESTS();
 #else
     std::string ssdFefaultType{ "SSD" };

--- a/TeamBest_SSD/main.cpp
+++ b/TeamBest_SSD/main.cpp
@@ -6,6 +6,7 @@ using namespace testing;
 #else
 #include "ssd_controller.h"
 #include "ssd_factory.h"
+#include "util.h"
 #endif
 
 
@@ -26,7 +27,7 @@ int main(int argc, char* argv[])
     for (int i = 1; i < argc; ++i)
         commandLine = commandLine + " " + std::string{ argv[i] };
 
-    ssdController.Run(commandLine);
+    ssdController.Run(BEST_UTILS::Trim(commandLine));
 
     return 0;
 #endif

--- a/TeamBest_SSD/ssd.h
+++ b/TeamBest_SSD/ssd.h
@@ -26,6 +26,10 @@ public:
 	void Erase(int lba, int size) override;
 	void WriteValueToOutputFile(const std::string& value) override;
 
+	bool IsValidAddress(int address);
+	bool IsValidValue(const std::string& value);
+	bool IsValidSIze(int lba, int size);
+
 	void SetAddressRange(int addressMin, int addressMax);
 	std::pair<int, int> GetAddressRange( );
 
@@ -34,9 +38,6 @@ private:
 
 	bool IsNandFileExist();
 	bool IsOutputFileExist();
-	bool IsValidAddress(int address);
-	bool IsValidValue(const std::string& value);	
-	bool IsValidSIze(int lba, int size);
 	
 	void UpdateValueAtAddress(int lba, const std::string& value);
 	std::vector<std::string> ReadDataForEntireAddress();
@@ -59,7 +60,7 @@ private:
 	inline static const std::string NAND_FILE_PATH{"ssd_nand.txt"};
 	inline static const std::string OUTPUT_FILE_PATH{ "ssd_output.txt" };
 
-	const std::regex VALID_DATA_PATTERN{ "^0x[0-9A-Fa-f]{8}$" };;
+	inline static const std::regex VALID_DATA_PATTERN{ "^0x[0-9A-F]{8}$" };
 	inline static const std::string ERROR_MESSAGE{ "ERROR" };
 
 };

--- a/TeamBest_SSD/ssd_controller.cpp
+++ b/TeamBest_SSD/ssd_controller.cpp
@@ -32,6 +32,35 @@ bool SSDController::IsValidCommand(const std::vector<std::string>& commandTokens
             && commandParamCount != COMMAND_PRAM_COUNT[i]) return false;
     }
 
+    if (commandName == VALID_COMMAND_LIST[SSD_COMMAND_TYPES::WRITE]) {
+        std::shared_ptr<SSD> curSSD = std::static_pointer_cast<SSD>(this->ssd);
+        int address = std::stoi(commandTokens[SSD_COMMAND_PARAM_INDEX::ADDRESS]);
+        std::string value = commandTokens[SSD_COMMAND_PARAM_INDEX::VALUE];
+
+        if (!curSSD->IsValidAddress(address)) {
+            curSSD->WriteValueToOutputFile(ERROR_MESSAGE);
+            return false;
+        }
+        if (!curSSD->IsValidValue(value)) {
+            curSSD->WriteValueToOutputFile(ERROR_MESSAGE);
+            return false;
+        }
+    }
+    else if (commandName == VALID_COMMAND_LIST[SSD_COMMAND_TYPES::ERASE]) {
+        std::shared_ptr<SSD> curSSD = std::static_pointer_cast<SSD>(this->ssd);
+        int address = std::stoi(commandTokens[SSD_COMMAND_PARAM_INDEX::ADDRESS]);
+        int size = std::stoi(commandTokens[SSD_COMMAND_PARAM_INDEX::SIZE]);
+
+        if (!curSSD->IsValidAddress(address)) {
+            curSSD->WriteValueToOutputFile(ERROR_MESSAGE);
+            return false;
+        }
+        if (!curSSD->IsValidSIze(address, size)) {
+            curSSD->WriteValueToOutputFile(ERROR_MESSAGE);
+            return false;
+        }
+    }
+
     return true;
 }
 

--- a/TeamBest_SSD/ssd_controller.cpp
+++ b/TeamBest_SSD/ssd_controller.cpp
@@ -12,7 +12,8 @@ bool SSDController::Run(const std::string& orgCommand) {
     std::string command = orgCommand;
     ConvertFirstLetterToUpperCase(command);
 	std::vector<std::string> tokens = BEST_UTILS::StringTokenizer(command);
-    
+    if (tokens.empty()) return false;
+
     if (!IsValidCommand(tokens)) return false;
 
     Execute(tokens, command);

--- a/TeamBest_SSD/ssd_controller.cpp
+++ b/TeamBest_SSD/ssd_controller.cpp
@@ -32,9 +32,18 @@ bool SSDController::IsValidCommand(const std::vector<std::string>& commandTokens
             && commandParamCount != COMMAND_PRAM_COUNT[i]) return false;
     }
 
+    if (commandName == VALID_COMMAND_LIST[SSD_COMMAND_TYPES::READ]) {
+        std::string addressStr = commandTokens[SSD_COMMAND_PARAM_INDEX::ADDRESS];
+        if (!BEST_UTILS::IsNumericOnly(addressStr)) return false;
+    }
+
     if (commandName == VALID_COMMAND_LIST[SSD_COMMAND_TYPES::WRITE]) {
         std::shared_ptr<SSD> curSSD = std::static_pointer_cast<SSD>(this->ssd);
-        int address = std::stoi(commandTokens[SSD_COMMAND_PARAM_INDEX::ADDRESS]);
+
+        std::string addressStr = commandTokens[SSD_COMMAND_PARAM_INDEX::ADDRESS];
+        if(!BEST_UTILS::IsNumericOnly(addressStr)) return false;
+            
+        int address = std::stoi(addressStr);
         std::string value = commandTokens[SSD_COMMAND_PARAM_INDEX::VALUE];
 
         if (!curSSD->IsValidAddress(address)) {
@@ -48,8 +57,14 @@ bool SSDController::IsValidCommand(const std::vector<std::string>& commandTokens
     }
     else if (commandName == VALID_COMMAND_LIST[SSD_COMMAND_TYPES::ERASE]) {
         std::shared_ptr<SSD> curSSD = std::static_pointer_cast<SSD>(this->ssd);
-        int address = std::stoi(commandTokens[SSD_COMMAND_PARAM_INDEX::ADDRESS]);
-        int size = std::stoi(commandTokens[SSD_COMMAND_PARAM_INDEX::SIZE]);
+
+        std::string addressStr = commandTokens[SSD_COMMAND_PARAM_INDEX::ADDRESS];
+        std::string sizeStr = commandTokens[SSD_COMMAND_PARAM_INDEX::SIZE];
+        if (!BEST_UTILS::IsNumericOnly(addressStr)) return false;
+        if (!BEST_UTILS::IsNumericOnly(sizeStr)) return false;
+
+        int address = std::stoi(addressStr);
+        int size = std::stoi(sizeStr);
 
         if (!curSSD->IsValidAddress(address)) {
             curSSD->WriteValueToOutputFile(ERROR_MESSAGE);

--- a/TeamBest_SSD/ssd_controller.h
+++ b/TeamBest_SSD/ssd_controller.h
@@ -63,6 +63,7 @@ private:
 		2,
 		0
 	};
+	const std::string ERROR_MESSAGE{ "ERROR" };
 };
 
 inline void SSDController::SetExecutor(std::shared_ptr<ISSD> ssdExecutor) {

--- a/TeamBest_SSD/util.h
+++ b/TeamBest_SSD/util.h
@@ -51,10 +51,21 @@ namespace BEST_UTILS {
         return tokens;
     }
 
+
     inline std::pair<int, int> getMinMax(std::vector<int> vec) {
         std::sort(vec.begin(), vec.end());
         int min = vec[0];
         int max = vec[3];
         return { min, max };
+    }
+
+    inline bool IsNumericOnly(const std::string& str) {
+        if (str.empty()) return false;
+        for (char ch : str) {
+            if (!std::isdigit(static_cast<unsigned char>(ch))) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/TeamBest_SSD/util.h
+++ b/TeamBest_SSD/util.h
@@ -6,6 +6,16 @@
 #include <vector>
 
 namespace BEST_UTILS {
+    inline std::string Trim(const std::string& str) {
+        auto begin = std::find_if_not(str.begin(), str.end(), ::isspace);
+        auto end = std::find_if_not(str.rbegin(), str.rend(), ::isspace).base();
+
+        if (begin >= end)
+            return "";
+
+        return std::string(begin, end);
+    }
+
     inline void ToUpper(char & input) {
         input = std::toupper(input);
     }


### PR DESCRIPTION
리펙토링을 하려 했지만, 버그가 발견 되어 버그 먼저 잡았습니다.
덕분에 코드가 지저분해져서 리펙토링할 맛이 나네요.
버그 잡느라 가독성이 많이 떨어진 IsValidCommand 함수에 대해 리펙토링 진행해보겠습니다.

1. 입력값에 숫자가 들어와야 하는데
숫자+문자 인 경우 에러로 인식하지 않고
숫자로 변환 가능한 부분까지만 숫자로 변환해 사용하고 있음

ex. ssd R 1abc

이와 같이 입력값 전체가 숫자가 아닐 경우 정상적이지 않는 경우로
처리하여 ssd, commandBuffer에 명령을 보내지 않게 함

2. Write/Erase의 경우 ssd를 직접사용하지 않고 commandBuffer를 사용하는데
ssd는 주소, 값 등의 유효성을 검사하지만
commandBuffer에서는 유효성 검사를 하지 않는 문제가 있었음.

commandBuffer에 command를 추가하지 전에 파라미터의 유효성을 검사하도록 수정

3. Trim 함수 추가, 입력 파라미터에서 앞뒤 공백 문자 제거
4. 사용자 입력이 Empty인 경우 바로 리턴하도록  처리