### PR TITLE
FastRead bug-fix

### DIFF
--- a/TeamBest_SSD/TeamBest_SSD.vcxproj
+++ b/TeamBest_SSD/TeamBest_SSD.vcxproj
@@ -158,10 +158,6 @@
     <ClInclude Include="TestCommons.h" />
     <ClInclude Include="util.h" />
   </ItemGroup>
-  <ItemGroup>
-    <Text Include="..\x64\Release\ssd_nand.txt" />
-    <Text Include="..\x64\Release\ssd_output.txt" />
-  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\gmock.1.11.0\build\native\gmock.targets" Condition="Exists('..\packages\gmock.1.11.0\build\native\gmock.targets')" />

--- a/TeamBest_SSD/TestCommandBuffer.cpp
+++ b/TeamBest_SSD/TestCommandBuffer.cpp
@@ -239,6 +239,73 @@ TEST(TestCommandBuffer, TestFastReadWhenBufferAvailable) {
 	EXPECT_EQ(expected, value);
 }
 
+TEST(TestCommandBuffer, TestFastReadWhenBufferAvailable_WExist) {
+	std::string BUFFER_DIR = "buffer";
+
+	RemoveDirectoryAndRecreate(BUFFER_DIR);
+
+	std::vector<std::string> bufferNames = {
+		{"1_E 3 4"},
+		{"2_W 72 0x12345678" },
+		{"3_empty"},
+		{"4_empty"},
+		{"5_empty"}
+	};
+	MakeBufferFiles(bufferNames, BUFFER_DIR);
+
+	CommandBuffer buffers;
+	int targetAddress = 72;
+	std::string value = buffers.FastRead(targetAddress);
+
+	std::string expected{ "0x12345678" };
+	EXPECT_EQ(expected, value);
+}
+
+TEST(TestCommandBuffer, TestFastReadWhenBufferAvailable_EExist) {
+	std::string BUFFER_DIR = "buffer";
+
+	RemoveDirectoryAndRecreate(BUFFER_DIR);
+
+	std::vector<std::string> bufferNames = {
+		{"1_E 3 4"},
+		{"2_W 72 0x12345678" },
+		{"3_E 72 1"},
+		{"4_empty"},
+		{"5_empty"}
+	};
+	MakeBufferFiles(bufferNames, BUFFER_DIR);
+
+	CommandBuffer buffers;
+	int targetAddress = 72;
+	std::string value = buffers.FastRead(targetAddress);
+
+	std::string expected{ "0x00000000" };
+	EXPECT_EQ(expected, value);
+}
+
+
+TEST(TestCommandBuffer, TestFastReadWhenBufferAvailable_ERangeExist) {
+	std::string BUFFER_DIR = "buffer";
+
+	RemoveDirectoryAndRecreate(BUFFER_DIR);
+
+	std::vector<std::string> bufferNames = {
+		{"1_E 3 4"},
+		{"2_W 72 0x12345678" },
+		{"3_E 68 7"},
+		{"4_empty"},
+		{"5_empty"}
+	};
+	MakeBufferFiles(bufferNames, BUFFER_DIR);
+
+	CommandBuffer buffers;
+	int targetAddress = 72;
+	std::string value = buffers.FastRead(targetAddress);
+
+	std::string expected{ "0x00000000" };
+	EXPECT_EQ(expected, value);
+}
+
 TEST(TestCommandBuffer, TestFlushWhenBufferEmpty) {
 	std::string BUFFER_DIR = "buffer";
 

--- a/TeamBest_SSD/command_buffer.cpp
+++ b/TeamBest_SSD/command_buffer.cpp
@@ -27,13 +27,25 @@ std::vector<std::string> CommandBuffer::Flush() {
 std::string CommandBuffer::FastRead(int targetAddress) {
 	std::vector<std::string> commandsInBuffer = ReadBuffers();
 
-	for (const auto& command : commandsInBuffer) {
-		auto tokens = BEST_UTILS::StringTokenizer(command);
+	for (auto it = commandsInBuffer.rbegin(); it != commandsInBuffer.rend(); ++it) {
+		auto tokens = BEST_UTILS::StringTokenizer(*it);
 		std::string command = tokens[COMMAND_PARAM_INDEX_WRITE::COMMAND_NAME];
-		int addressInCommand = std::stoi(tokens[COMMAND_PARAM_INDEX_WRITE::ADDRESS]);
-		if (command == WRITE_COMMAND_NAME && targetAddress == addressInCommand) {
-			return tokens[COMMAND_PARAM_INDEX_WRITE::VALUE];
-		}	
+		if (command == WRITE_COMMAND_NAME) {
+			int addressInCommand = std::stoi(tokens[COMMAND_PARAM_INDEX_WRITE::ADDRESS]);
+			if (targetAddress == addressInCommand) {
+				return tokens[COMMAND_PARAM_INDEX_WRITE::VALUE];
+			}
+		}
+		else if(command == ERASE_COMMAND_NAME) {
+			int addressInCommand = std::stoi(tokens[COMMAND_PARAM_INDEX_ERASE::ADDRESS]);
+			int sizeInCommand = std::stoi(tokens[COMMAND_PARAM_INDEX_ERASE::SIZE]);
+
+			int startAddress = addressInCommand;
+			int endAddress = startAddress + sizeInCommand -1;
+			if (targetAddress >= startAddress && targetAddress <= endAddress) {
+				return MEMORY_INIT_VALUE;
+			}			
+		}
 	}
 
 	return {};

--- a/TeamBest_SSD/command_buffer.h
+++ b/TeamBest_SSD/command_buffer.h
@@ -86,8 +86,9 @@ private:
 	inline static const std::string DELIMITER{ "_" };
 
 	inline static const std::string WRITE_COMMAND_NAME = { "W" };
+	inline static const std::string ERASE_COMMAND_NAME = { "E" };
 
-
+	inline static const std::string MEMORY_INIT_VALUE = { "0x00000000" };
 };
 
 

--- a/TeamBest_SSD/main.cpp
+++ b/TeamBest_SSD/main.cpp
@@ -14,7 +14,7 @@ int main(int argc, char* argv[])
 {
 #ifdef _DEBUG
     ::testing::InitGoogleMock();
-    //::testing::GTEST_FLAG(filter) = "TestCommandBuffer.*";
+    ::testing::GTEST_FLAG(filter) = "TestCommandBuffer.*";
     return RUN_ALL_TESTS();
 #else
     std::string ssdFefaultType{ "SSD" };


### PR DESCRIPTION
FastRead가 Buffer에 기록된 내용 중에
W인 경우에 대해서만 fastRead 가능 여부를 판단하고 있었음
E인 경우에도 평가하도록 수정

W는 주소가 일치할 경우 fastRead 가능이고
E는 target주소가 E의 범위에 포함되면 fastRead 가능